### PR TITLE
Development

### DIFF
--- a/features/support/helpers/eshelf_helper.rb
+++ b/features/support/helpers/eshelf_helper.rb
@@ -1,7 +1,4 @@
 module Browbeat
   module EshelfHelper
-    def first_result
-      first('.results .result')
-    end
   end
 end

--- a/lib/browbeat/application.rb
+++ b/lib/browbeat/application.rb
@@ -3,6 +3,7 @@ module Browbeat
     include Browbeat::Helpers::ApiPageIdsHelper
 
     attr_reader :name, :symbol, :status_page_production_id, :status_page_staging_id
+    attr_accessor :status_page_production_component, :status_page_staging_component
 
     def initialize(name:, symbol:, status_page_production_id:, status_page_staging_id:)
       @name = name
@@ -23,11 +24,11 @@ module Browbeat
     end
 
     def status_page_production_component
-      @component ||= get_status_page_component(status_page_production_id, status_page_production_page_id)
+      @status_page_production_component ||= get_status_page_component(status_page_production_id, status_page_production_page_id)
     end
 
     def status_page_staging_component
-      @staging_component ||= get_status_page_component(status_page_staging_id, status_page_staging_page_id)
+      @status_page_staging_component ||= get_status_page_component(status_page_staging_id, status_page_staging_page_id)
     end
 
     private

--- a/lib/browbeat/application.rb
+++ b/lib/browbeat/application.rb
@@ -17,6 +17,7 @@ module Browbeat
     #   application.set_status_page_status 'major_outage', environment: :staging
     def set_status_page_status(status_type, environment: :production)
       component = send("status_page_#{environment}_component")
+      return if component.status == status_type
       component.status = status_type
       component.save
     end

--- a/lib/browbeat/application_collection.rb
+++ b/lib/browbeat/application_collection.rb
@@ -1,11 +1,19 @@
 module Browbeat
   class ApplicationCollection < CollectionBase
+    include Browbeat::Helpers::ApiPageIdsHelper
 
     LIST_FILEPATH = 'config/application_list.yml'
 
     def load_yml
       @members = all_applications_yaml.map do |app_symbol, attributes|
         Application.new(**symbolize_keys(attributes).merge(symbol: app_symbol))
+      end
+      self
+    end
+
+    def load_components
+      %w[production staging].each do |environment|
+        load_components_for(environment)
       end
       self
     end
@@ -17,6 +25,13 @@ module Browbeat
 
     def symbolize_keys(hash)
       hash.map{|k,v| [k.to_sym, v] }.to_h
+    end
+    
+    def load_components_for(environment)
+      components = StatusPage::API::ComponentList.new(send("status_page_#{environment}_page_id")).get.to_a
+      each do |application|
+        application.send("status_page_#{environment}_component=", components.detect{|c| c.id == application.send("status_page_#{environment}_id") })
+      end
     end
   end
 end

--- a/lib/browbeat/failure_tracker.rb
+++ b/lib/browbeat/failure_tracker.rb
@@ -1,10 +1,11 @@
 module Browbeat
   class FailureTracker
 
-    attr_accessor :scenarios
+    attr_accessor :scenarios, :applications
 
     def initialize
       @scenarios = ScenarioCollection.new
+      @applications = ApplicationCollection.new.load_yml
     end
 
     def register_scenario(scenario)
@@ -12,11 +13,11 @@ module Browbeat
     end
 
     def sync_status_page
-      StatusSync.sync_status_page scenarios
+      StatusSync.sync_status_page scenarios, applications
     end
 
     def send_status_mail
-      StatusMailer.send_status scenarios
+      StatusMailer.send_status scenarios, applications
     end
 
   end

--- a/lib/browbeat/failure_tracker.rb
+++ b/lib/browbeat/failure_tracker.rb
@@ -5,7 +5,7 @@ module Browbeat
 
     def initialize
       @scenarios = ScenarioCollection.new
-      @applications = ApplicationCollection.new.load_yml
+      @applications = ApplicationCollection.new.load_yml.load_components
     end
 
     def register_scenario(scenario)

--- a/lib/browbeat/status_mailer.rb
+++ b/lib/browbeat/status_mailer.rb
@@ -2,14 +2,15 @@ module Browbeat
   class StatusMailer
     include Browbeat::Helpers::ApiPageIdsHelper
 
-    attr_reader :scenario_collection
+    attr_reader :scenario_collection, :application_collection
 
-    def self.send_status(scenario_collection)
-      new(scenario_collection).send_status_if_failed
+    def self.send_status(scenario_collection, application_collection)
+      new(scenario_collection, application_collection).send_status_if_failed
     end
 
-    def initialize(scenario_collection)
+    def initialize(scenario_collection, application_collection)
       @scenario_collection = scenario_collection
+      @application_collection = application_collection
     end
 
     def send_status_if_failed
@@ -64,15 +65,10 @@ module Browbeat
     end
 
     private
-
     def get_scenario_applications
-      application_list.select do |application|
+      application_collection.select do |application|
         scenario_application_symbols.include?(application.symbol)
       end
-    end
-
-    def application_list
-      @application_list ||= ApplicationCollection.new.load_yml
     end
 
     def scenario_application_symbols

--- a/lib/browbeat/status_sync.rb
+++ b/lib/browbeat/status_sync.rb
@@ -2,21 +2,22 @@ module Browbeat
   class StatusSync
     extend Browbeat::Helpers::ApiPageIdsHelper
 
-    attr_accessor :scenario_collection
+    attr_accessor :scenario_collection, :application_collection
 
     SUCCESS_STATUS_TYPE = 'operational'
     FAILURE_STATUS_TYPES = %w[major_outage partial_outage degraded_performance]
 
-    def self.sync_status_page(scenario_collection)
-      new(scenario_collection).sync_status_page
+    def self.sync_status_page(scenario_collection, application_collection)
+      new(scenario_collection, application_collection).sync_status_page
     end
 
-    def initialize(scenario_collection)
+    def initialize(scenario_collection, application_collection)
       @scenario_collection = scenario_collection
+      @application_collection = application_collection
     end
 
     def sync_status_page
-      application_list.each do |application|
+      application_collection.each do |application|
         next unless scenarios_for_application?(application)
         if tagged_scenarios_for_application?(application, :production)
           application.set_status_page_status status_for_application(application, :production)
@@ -51,10 +52,6 @@ module Browbeat
     end
 
     private
-    def application_list
-      @application_list ||= ApplicationCollection.new.load_yml
-    end
-
     def failed_scenarios
       @failed_scenarios ||= scenario_collection.select(&:failed?).select(&:failure_severity)
     end

--- a/spec/lib/browbeat/application_collection_spec.rb
+++ b/spec/lib/browbeat/application_collection_spec.rb
@@ -12,6 +12,9 @@ describe Browbeat::ApplicationCollection do
     end
 
     it { is_expected.to match_array [subject[0], subject[1]] }
+    
+    it { is_expected.to eq collection }
+    
     it "should have 2 items" do
       expect(subject.length).to eq 2
     end
@@ -23,6 +26,64 @@ describe Browbeat::ApplicationCollection do
       expect(Browbeat::Application).to receive(:new).with(name: "Login", status_page_production_id: "abcd1234", status_page_staging_id: "efgh9876", symbol: "login")
       expect(Browbeat::Application).to receive(:new).with(name: "E-Shelf", status_page_production_id: "wxyz1234", status_page_staging_id: "vuts9876", symbol: "eshelf")
       subject
+    end
+  end
+  
+  describe "load_components" do
+    subject{ collection.load_components }
+    
+    context "with members having status page ids" do
+      let(:collection){ described_class.new [application1, application2, application3] }
+      let(:application1){ Browbeat::Application.new name: "App 1", symbol: "app1", status_page_production_id: "aaaa", status_page_staging_id: "zzzz" }
+      let(:application2){ Browbeat::Application.new name: "App 2", symbol: "app2", status_page_production_id: "bbbb", status_page_staging_id: "yyyy" }
+      let(:application3){ Browbeat::Application.new name: "App 3", symbol: "app3", status_page_production_id: "cccc", status_page_staging_id: "xxxx" }
+      
+      context "with status page key and page IDs set" do
+        let(:production_page_id){ "abcdefg" }
+        let(:staging_page_id){ "tuvwxyz" }
+        around do |example|
+          with_modified_env STATUS_PAGE_PAGE_ID: production_page_id, STATUS_PAGE_STAGING_PAGE_ID: staging_page_id do
+            example.run
+          end
+        end
+        
+        let(:production_component_list){ instance_double StatusPage::API::ComponentList, get: populated_production_component_list }
+        let(:staging_component_list){ instance_double StatusPage::API::ComponentList, get: populated_staging_component_list }
+        let(:populated_production_component_list){ instance_double StatusPage::API::ComponentList, to_a: production_components }
+        let(:populated_staging_component_list){ instance_double StatusPage::API::ComponentList, to_a: staging_components }
+        let(:production_components){ [production_component1, production_component2, production_component3, production_component4] }
+        let(:production_component1){ instance_double StatusPage::API::Component, id: "bbbb" }
+        let(:production_component2){ instance_double StatusPage::API::Component, id: "cccc" }
+        let(:production_component3){ instance_double StatusPage::API::Component, id: "dddd" }
+        let(:production_component4){ instance_double StatusPage::API::Component, id: "aaaa" }
+        let(:staging_components){ [staging_component1, staging_component2, staging_component3, staging_component4] }
+        let(:staging_component1){ instance_double StatusPage::API::Component, id: "wwww" }
+        let(:staging_component2){ instance_double StatusPage::API::Component, id: "xxxx" }
+        let(:staging_component3){ instance_double StatusPage::API::Component, id: "yyyy" }
+        let(:staging_component4){ instance_double StatusPage::API::Component, id: "zzzz" }
+        before do
+          allow(StatusPage::API::ComponentList).to receive(:new).with(production_page_id).and_return production_component_list
+          allow(StatusPage::API::ComponentList).to receive(:new).with(staging_page_id).and_return staging_component_list
+          populated_production_component_list.instance_variable_set("@components", production_components)
+          populated_staging_component_list.instance_variable_set("@components", staging_components)
+        end
+        
+        it { is_expected.to eq collection }
+        
+        it "should assign production components" do
+          subject
+          expect(application1.status_page_production_component).to eq production_component4
+          expect(application2.status_page_production_component).to eq production_component1
+          expect(application3.status_page_production_component).to eq production_component2
+        end
+        
+        it "should assign staging components" do
+          subject
+          expect(application1.status_page_staging_component).to eq staging_component4
+          expect(application2.status_page_staging_component).to eq staging_component3
+          expect(application3.status_page_staging_component).to eq staging_component2
+        end
+      end
     end
   end
 

--- a/spec/lib/browbeat/application_spec.rb
+++ b/spec/lib/browbeat/application_spec.rb
@@ -2,13 +2,6 @@ require 'spec_helper'
 require 'browbeat'
 
 describe Browbeat::Application do
-  # describe "class methods" do
-  #   describe "self.list_all" do
-  #     subject{ described_class.list_all }
-  #     
-  #
-  #   end
-  # end
 
   describe "instance methods" do
     let(:name){ "Login" }
@@ -18,39 +11,95 @@ describe Browbeat::Application do
     let(:application){ described_class.new(name: name, status_page_production_id: status_page_production_id, status_page_staging_id: status_page_staging_id, symbol: symbol) }
 
     describe "set_status_page_status" do
-      let(:component){ instance_double StatusPage::API::Component, save: true, :"status=" => true }
+      let(:component){ instance_double StatusPage::API::Component, save: true, :"status=" => true, status: previous_status }
 
       context "with no environment specified" do
         subject { application.set_status_page_status "some_status" }
         before { allow(application).to receive(:status_page_production_component).and_return component }
 
-        it "should set component status and save with correct parameters" do
-          expect(component).to receive(:status=).with("some_status").ordered
-          expect(component).to receive(:save).ordered
-          subject
+        context "with different status previously" do
+          let(:previous_status){ "other_status" }
+          
+          it { is_expected.to be_truthy }
+          
+          it "should set component status and save with correct parameters" do
+            expect(component).to receive(:status=).with("some_status").ordered
+            expect(component).to receive(:save).ordered
+            subject
+          end
+        end
+        
+        context "with same status previously" do
+          let(:previous_status){ "some_status" }
+          
+          it { is_expected.to be_falsy }
+          
+          it "should not set component status to avoid API call" do
+            expect(component).to_not receive(:status=)
+            expect(component).to_not receive(:save)
+            subject
+          end
         end
       end
 
       context "with environment: :staging" do
         subject { application.set_status_page_status "some_status", environment: :staging }
         before { allow(application).to receive(:status_page_staging_component).and_return component }
-
-        it "should set component status and save with correct parameters" do
-          expect(component).to receive(:status=).with("some_status").ordered
-          expect(component).to receive(:save).ordered
-          subject
+        
+        context "with different status previously" do
+          let(:previous_status){ "other_status" }
+          
+          it { is_expected.to be_truthy }
+          
+          it "should set component status and save with correct parameters" do
+            expect(component).to receive(:status=).with("some_status").ordered
+            expect(component).to receive(:save).ordered
+            subject
+          end
         end
+        
+        context "with same status previously" do
+          let(:previous_status){ "some_status" }
+          
+          it { is_expected.to be_falsy }
+          
+          it "should not set component status to avoid API call" do
+            expect(component).to_not receive(:status=)
+            expect(component).to_not receive(:save)
+            subject
+          end
+        end
+        
       end
 
       context "with environment: :production" do
         subject { application.set_status_page_status "some_status", environment: :production }
         before { allow(application).to receive(:status_page_production_component).and_return component }
-
-        it "should set component status and save with correct parameters" do
-          expect(component).to receive(:status=).with("some_status").ordered
-          expect(component).to receive(:save).ordered
-          subject
+        
+        context "with different status previously" do
+          let(:previous_status){ "other_status" }
+          
+          it { is_expected.to be_truthy }
+          
+          it "should set component status and save with correct parameters" do
+            expect(component).to receive(:status=).with("some_status").ordered
+            expect(component).to receive(:save).ordered
+            subject
+          end
         end
+        
+        context "with same status previously" do
+          let(:previous_status){ "some_status" }
+          
+          it { is_expected.to be_falsy }
+          
+          it "should not set component status to avoid API call" do
+            expect(component).to_not receive(:status=)
+            expect(component).to_not receive(:save)
+            subject
+          end
+        end
+        
       end
     end
 

--- a/spec/lib/browbeat/failure_tracker_spec.rb
+++ b/spec/lib/browbeat/failure_tracker_spec.rb
@@ -4,15 +4,13 @@ require 'browbeat'
 describe Browbeat::FailureTracker do
   let(:tracker){ described_class.new }
 
-  describe "scenarios"
-
   describe "register_scenario" do
     let(:scenario){ instance_double Cucumber::Ast::Scenario }
 
     context "initial call" do
       subject{ tracker.register_scenario scenario }
 
-      it "should add scenario to collection" do
+      it "should add scenario to scenario_collection" do
         subject
         expect(tracker.scenarios.to_a.map(&:cucumber_scenario)).to include scenario
       end
@@ -27,7 +25,7 @@ describe Browbeat::FailureTracker do
       let(:scenario2){ instance_double Browbeat::Scenario }
       let(:scenario3){ instance_double Browbeat::Scenario }
 
-      it "should retain all scenarios in collection" do
+      it "should retain all scenarios in scenario_collection" do
         subject
         expect(tracker.scenarios.to_a.map(&:cucumber_scenario)).to include scenario
         expect(tracker.scenarios.to_a.map(&:cucumber_scenario)).to include scenario2
@@ -38,9 +36,11 @@ describe Browbeat::FailureTracker do
 
   describe "sync_status_page" do
     subject{ tracker.sync_status_page }
-    let(:collection){ Browbeat::ScenarioCollection }
+    let(:scenario_collection){ instance_double Browbeat::ScenarioCollection }
+    let(:application_collection){ instance_double Browbeat::ApplicationCollection }
     before do
-      allow(tracker).to receive(:scenarios).and_return collection
+      allow_any_instance_of(Browbeat::ApplicationCollection).to receive(:load_yml).and_return application_collection
+      allow(tracker).to receive(:scenarios).and_return scenario_collection
       allow(Browbeat::StatusSync).to receive(:sync_status_page)
     end
 
@@ -50,16 +50,18 @@ describe Browbeat::FailureTracker do
     end
 
     it "should call sync_status_page with scenarios" do
-      expect(Browbeat::StatusSync).to receive(:sync_status_page).with(collection)
+      expect(Browbeat::StatusSync).to receive(:sync_status_page).with(scenario_collection, application_collection)
       subject
     end
   end
 
   describe "send_status_mail" do
     subject{ tracker.send_status_mail }
-    let(:collection){ Browbeat::ScenarioCollection }
+    let(:scenario_collection){ instance_double Browbeat::ScenarioCollection }
+    let(:application_collection){ instance_double Browbeat::ApplicationCollection }
     before do
-      allow(tracker).to receive(:scenarios).and_return collection
+      allow_any_instance_of(Browbeat::ApplicationCollection).to receive(:load_yml).and_return application_collection
+      allow(tracker).to receive(:scenarios).and_return scenario_collection
       allow(Browbeat::StatusMailer).to receive(:send_status)
     end
 
@@ -69,7 +71,7 @@ describe Browbeat::FailureTracker do
     end
 
     it "should call sync_status_page with scenarios" do
-      expect(Browbeat::StatusMailer).to receive(:send_status).with(collection)
+      expect(Browbeat::StatusMailer).to receive(:send_status).with(scenario_collection, application_collection)
       subject
     end
   end

--- a/spec/lib/browbeat/status_mailer_spec.rb
+++ b/spec/lib/browbeat/status_mailer_spec.rb
@@ -4,16 +4,17 @@ require 'browbeat'
 describe Browbeat::StatusMailer do
   describe "class methods" do
     describe "self.send_status" do
-      subject { described_class.send_status scenario_collection }
+      subject { described_class.send_status scenario_collection, application_collection }
       let(:mailer){ instance_double described_class }
       let(:scenario_collection){ instance_double Browbeat::ScenarioCollection }
+      let(:application_collection){ instance_double Browbeat::ApplicationCollection }
       before do
         allow(described_class).to receive(:new).and_return mailer
         allow(mailer).to receive(:send_status_if_failed).and_return true
       end
 
       it "should instantiate instance correctly" do
-        expect(described_class).to receive(:new).with scenario_collection
+        expect(described_class).to receive(:new).with scenario_collection, application_collection
         subject
       end
 
@@ -25,8 +26,9 @@ describe Browbeat::StatusMailer do
   end
 
   describe "instance methods" do
-    let(:mailer){ described_class.new scenario_collection }
+    let(:mailer){ described_class.new scenario_collection, application_collection }
     let(:scenario_collection){ instance_double Browbeat::ScenarioCollection }
+    let(:application_collection){ instance_double Browbeat::ApplicationCollection }
 
     describe "send_status_if_failed" do
       subject { mailer.send_status_if_failed }
@@ -356,10 +358,7 @@ describe Browbeat::StatusMailer do
       let(:application1){ instance_double Browbeat::Application, symbol: "xxxx" }
       let(:application2){ instance_double Browbeat::Application, symbol: "yyyy" }
       let(:application3){ instance_double Browbeat::Application, symbol: "zzzz" }
-      let(:application_list){ Browbeat::ApplicationCollection.new(applications) }
-      before do
-        allow_any_instance_of(Browbeat::ApplicationCollection).to receive(:load_yml).and_return application_list
-      end
+      let(:application_collection){ Browbeat::ApplicationCollection.new(applications) }
 
       context "with scenarios" do
         let(:scenario_collection){ Browbeat::ScenarioCollection.new [scenario1, scenario2, scenario3] }


### PR DESCRIPTION
Consolidates API calls:
- instantiates application list once (in `FailureTracker`) instead of twice (in `StatusMailer` and `StatusSync`)
- populates `StatusPage::API::Component` collectively (2 calls total) instead of individually (2 calls for each application)